### PR TITLE
ci: Setup Travis CI for continuous integration testing on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+
+jdk:
+  - oraclejdk8
+  - openjdk8
+
+script:
+  - ./gradlew -u -S --no-daemon --no-parallel check
+
+cache:
+  directories:
+    - $HOME/.gradle/


### PR DESCRIPTION
Setup Travis CI for continuous integration testing on Linux.
Setup link: https://github.com/marketplace/travis-ci
Example build: https://travis-ci.com/ChristianMurphy/fbms/builds/74574860